### PR TITLE
Update config.toml

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,6 +1,7 @@
 baseURL = "/"
 languageCode = "en-us"
 title = "rougon"
+ignoreErrors = ["error-output-taxonomy"]
 
 [outputs]
   page = ["json","players"]
@@ -10,7 +11,7 @@ title = "rougon"
   taxonomy = ["json", "players"]
 
 [mediaTypes."text/netlify"]
-suffix = ""
+suffixes = ""
 delimiter = ""
 
 [outputFormats.players]

--- a/config.toml
+++ b/config.toml
@@ -9,6 +9,7 @@ ignoreErrors = ["error-output-taxonomy"]
   teams = ["json"]
   section = ["json"]
   taxonomy = ["json", "players"]
+  term = ["json"]
 
 [mediaTypes."text/netlify"]
 suffixes = ""


### PR DESCRIPTION
$ hugo server
Error: from config: MediaType.Suffix is removed. Before Hugo 0.44 this was used both to set a custom file suffix and as way
to augment the mediatype definition (what you see after the "+", e.g. "image/svg+xml").

This had its limitations. For one, it was only possible with one file extension per MIME type.

Now you can specify multiple file suffixes using "suffixes", but you need to specify the full MIME type
identifier:

[mediaTypes]
[mediaTypes."image/svg+xml"]
suffixes = ["svg", "abc" ]

In most cases, it will be enough to just change:

[mediaTypes]
[mediaTypes."my/custom-mediatype"]
suffix = "txt"

To:

[mediaTypes]
[mediaTypes."my/custom-mediatype"]
suffixes = ["txt"]

Note that you can still get the Media Type's suffix from a template: {{ $mediaType.Suffix }}. But this will now map to the MIME type filename.

$ hugo serve --disableFastRender
You have configured output formats for 'taxonomy' in your site configuration. In Hugo 0.73.0 we fixed these to be what most people expect (taxonomy and term).
But this also means that your site configuration may not do what you expect. If it is correct, you can suppress this message by following the instructions below.
If you feel that this should not be logged as an ERROR, you can ignore it by adding this to your site config:
ignoreErrors = ["error-output-taxonomy"]